### PR TITLE
fix fatal on toString

### DIFF
--- a/lib/Model/Metadata/FileDescriptor.php
+++ b/lib/Model/Metadata/FileDescriptor.php
@@ -148,8 +148,8 @@ class FileDescriptor extends BaseModel
             ", type='" . $this->type . '\'' .
             ", size=" . $this->size .
             ", acl='" . $this->acl . '\'' .
-            ", dateCreated=" . $this->dateCreated->format(DateTime::ISO8601) .
-            ", dateUpdated=" . $this->dateUpdated->format(DateTime::ISO8601) .
+            ", dateCreated=" . (is_object($this->dateCreated) ? $this->dateCreated->format(DateTime::ISO8601) : $this->dateCreated) .
+            ", dateUpdated=" . (is_object($this->dateUpdated) ? $this->dateUpdated->format(DateTime::ISO8601) : $this->dateUpdated) .
             '}';
     }
 }


### PR DESCRIPTION
The dates value is string, not an object.
Fatal error "lib/Model/Metadata/FileDescriptor.php : Source - Error : Call to a member function format() on string (0)  occurs when calling : $fileDescriptor = $imageOperation($operationRequest); echo $fileDescriptor->__toString();"